### PR TITLE
Retransmit lost messages after socket.io disconnect and reconnect

### DIFF
--- a/HttpsProxy.ts
+++ b/HttpsProxy.ts
@@ -17,7 +17,7 @@ export default class HttpsProxy {
 
             const client_req = ctx.clientToProxyRequest;
             const client_res = ctx.proxyToClientResponse;
-            //console.log(ctx);
+            //Global.log(ctx);
 
             var sequenceNumber = ++Global.nextSequenceNumber;
             var remoteAddress = client_req.socket.remoteAddress;
@@ -31,10 +31,10 @@ export default class HttpsProxy {
 
             const reqUrl = url.parse(client_req.url ? client_req.url : '');
 
-            console.log(sequenceNumber, remoteAddress + ': ', client_req.method, client_req.url);
+            Global.log(sequenceNumber, remoteAddress + ': ', client_req.method, client_req.url);
 
             var startTime = Date.now();
-            console.log(reqUrl.protocol, reqUrl.pathname, reqUrl.search);
+            Global.log(reqUrl.protocol, reqUrl.pathname, reqUrl.search);
 
             // Find matching proxy configuration
             let proxyConfig;
@@ -61,7 +61,7 @@ export default class HttpsProxy {
 
             if(proxyConfig === undefined) {
                 let msg = 'No matching proxy configuration found for '+reqUrl.pathname;
-                console.log(sequenceNumber, msg);
+                Global.log(sequenceNumber, msg);
                 ctx.proxyToClientResponse.end('404 '+msg);
                 emitRequestToBrowser(
                     undefined,
@@ -77,18 +77,18 @@ export default class HttpsProxy {
             callback();
 
             function proxyRequest(proxyConfig: ProxyConfig) {
-                //console.log(sequenceNumber, 'proxyRequest');
+                //Global.log(sequenceNumber, 'proxyRequest');
 
                 client_req.on('close', function () {
-                    console.log(sequenceNumber, 'Client closed connection');
+                    Global.log(sequenceNumber, 'Client closed connection');
                 })
 
                 client_req.on('error', function (error) {
-                    console.log(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2));
+                    Global.error(sequenceNumber, 'Client connection error', JSON.stringify(error, null, 2));
                 })
 
                 client_res.on('error', function (error) {
-                    console.log(sequenceNumber, 'Server connection error', JSON.stringify(error, null, 2));
+                    Global.error(sequenceNumber, 'Server connection error', JSON.stringify(error, null, 2));
                     emitRequestToBrowser(
                         undefined,
                         client_req.url!,
@@ -99,7 +99,7 @@ export default class HttpsProxy {
 
                 let reqChunks: string = '';
                 ctx.onRequestData(function (ctx, chunk, callback) {
-                    //console.log('request data length: ' + chunk.length);
+                    //Global.log('request data length: ' + chunk.length);
                     reqChunks += chunk.toString();
                     return callback(undefined, chunk);
                 });
@@ -115,11 +115,11 @@ export default class HttpsProxy {
                 });
 
                 ctx.onResponse(function (ctx, callback) {
-                    //console.log('RESPONSE: http://' + ctx.clientToProxyRequest.headers.host + ctx.clientToProxyRequest.url);
+                    //Global.log('RESPONSE: http://' + ctx.clientToProxyRequest.headers.host + ctx.clientToProxyRequest.url);
 
                     let resChunks: string = '';
                     ctx.onResponseData(function (ctx, chunk, callback) {
-                        //console.log('response data length: ' + chunk.length);
+                        //Global.log('response data length: ' + chunk.length);
                         resChunks += chunk.toString();
                         return callback(undefined, chunk);
                     });

--- a/client/src/store/MessageQueueStore.ts
+++ b/client/src/store/MessageQueueStore.ts
@@ -53,7 +53,8 @@ export default class MessageQueueStore {
 		return this.stores;
 	}
 
-	@action public insert(message: Message) {
+	@action public insert(socketSeqNum: number, message: Message) {
+		console.log('insert', socketSeqNum, message.sequenceNumber);
 		if (this.stopped) return;
 		if (!message.proxyConfig?.recording) return;
 
@@ -91,9 +92,9 @@ export default class MessageQueueStore {
 			this.stores.splice(m, 0, messageStore);
 		}
 
-		// Shrink array when it is 100 larger then limit
-		if (this.stores.length >= this.limit + 100) {
-			this.stores.splice(0, 100);
+		// Shrink array when it is 1 larger than ghe limit
+		if (this.stores.length >= this.limit) {
+			this.stores.splice(0, 1);
 		}
 	}
 }

--- a/client/src/store/SocketStore.ts
+++ b/client/src/store/SocketStore.ts
@@ -37,8 +37,9 @@ export default class SocketStore {
 			console.log('socket error', e);
 		});
 
-		this.socket.on('reqResJson', (message: Message) => {
-			messageQueueStore.insert(message);
+		this.socket.on('reqResJson', (socketSeqNum: number, message: Message, callback: any) => {
+			messageQueueStore.insert(socketSeqNum, message);
+			callback(`${socketSeqNum} ${message.sequenceNumber} socket.io response`);
 		});
 	}
 

--- a/node-http-mitm-proxy/examples/forwardHttps.js
+++ b/node-http-mitm-proxy/examples/forwardHttps.js
@@ -52,10 +52,10 @@ proxy.listen({ port }, function() {
   console.log('> ' + cmd);
   require('child_process').exec(cmd, function (error, stdout, stderr) {
     if (error) {
-      console.error(`exec error: ${error}`);
+      Global.error(`exec error: ${error}`);
       return;
     }
-    console.log(`${stdout}`);
+    Global.log(`${stdout}`);
     assert(/DOCTYPE/.test(stdout));
     proxy.close();
   });

--- a/server/src/Global.ts
+++ b/server/src/Global.ts
@@ -1,5 +1,20 @@
 import ProxyConfigs from './ProxyConfigs';
+
+const DEBUG = false;
+
 export default class Global {
     static proxyConfigs: ProxyConfigs;
     static nextSequenceNumber: number = 0;
+
+    static log(...args: any[]) {
+        if (DEBUG) {
+            console.log(args);
+        }
+    }
+
+    static error(...args: any[]) {
+        if (DEBUG) {
+            console.error(args);
+        }
+    }
 }

--- a/server/src/LogProxy.ts
+++ b/server/src/LogProxy.ts
@@ -18,13 +18,13 @@ export default class LogProxy {
     if(proxyConfig.logProxyProcess) {
 			try {
 				const proc = proxyConfig.logProxyProcess;
-				//console.log('killing:', proc.pid);
+				//Global.log('killing:', proc.pid);
 				proc.stdout.removeAllListeners();
 				proc.stderr.removeAllListeners();
 				proc.removeAllListeners();
 				proc.kill('SIGINT');
 			} catch(e) {
-				console.log(e);
+				Global.error(e);
 			}
 		}
   }
@@ -32,7 +32,7 @@ export default class LogProxy {
 	start() {
 		LogProxy.destructor(this.proxyConfig);
 		this.retry = true;
-		console.log(`Monitoring log: ${this.command}`);
+		Global.log(`Monitoring log: ${this.command}`);
 		const tokens = this.command.split(' ');
 		const proc = spawn(tokens[0], tokens.slice(1));
 		//('start', proc.pid);
@@ -52,11 +52,11 @@ export default class LogProxy {
 		});
 
 		proc.on('error', error => {
-			console.log(`error: ${error} - ${this.command}`);
+			Global.error(`error: ${error} - ${this.command}`);
 		});
 
 		proc.on('exit', rc => {
-			console.log('LogProxy exiting:', this.command);
+			Global.log('LogProxy exiting:', this.command);
 			proc.stdout.removeAllListeners();
 			proc.stderr.removeAllListeners();
 			proc.removeAllListeners();
@@ -99,7 +99,7 @@ export default class LogProxy {
 			return;
 		}
 
-		console.log(`sendToBrowser log: ${this.command}`);
+		Global.log(`sendToBrowser log: ${this.command}`);
 		const seqNo = ++Global.nextSequenceNumber;
 		const message = await SocketIoMessage.buildRequest(
 			Date.now(),
@@ -118,7 +118,7 @@ export default class LogProxy {
 		message.protocol = 'log:';
 		Global.proxyConfigs.emitMessageToBrowser(message, this.proxyConfig);
 
-		//console.log('buffered:', this.recordCount, this.buffer.toString());
+		//Global.log('buffered:', this.recordCount, this.buffer.toString());
 		this.buffer = '';
 		this.recordCount = 0;
 	}

--- a/server/src/TcpProxy.ts
+++ b/server/src/TcpProxy.ts
@@ -12,12 +12,12 @@ import { NO_RESPONSE } from '../../common/Message';
 
 export default class TcpProxy {
     constructor(proxyConfig: ProxyConfig) {
-        //console.log('TcpProxy.ctor', proxyConfig);
+        //Global.log('TcpProxy.ctor', proxyConfig);
         this.startProxy(proxyConfig);
     }
 
     static destructor(proxyConfig: ProxyConfig) {
-        //console.log('TcpProxy.dtor', proxyConfig);
+        //Global.log('TcpProxy.dtor', proxyConfig);
         if(proxyConfig._server) proxyConfig._server.close();
     }
 
@@ -52,7 +52,7 @@ export default class TcpProxy {
             if (++retries < 10) {
                 setTimeout(() => listen(server), wait *= 2);
             } else {
-                console.log('TcpProxy server error', err);
+                Global.log('TcpProxy server error', err);
             }
         });
 
@@ -60,7 +60,7 @@ export default class TcpProxy {
 
         function listen(server: net.Server) {
             server.listen(sourcePort, function () {
-                console.log("Listening on port " + sourcePort + " for target host " + targetHost + ":" + targetPort)
+                Global.log("Listening on port " + sourcePort + " for target host " + targetHost + ":" + targetPort)
             });
             proxyConfig._server = server;
         }
@@ -80,25 +80,25 @@ export default class TcpProxy {
             let targetSocket: net.Socket | tls.TLSSocket;
             if (!targetUseTls) {
                 targetSocket = net.connect(targetPort, targetHost, () => {
-                    //console.log('connected to target');
+                    //Global.log('connected to target');
                 });
             } else {
                 targetSocket = tls.connect(targetPort, targetHost, {}, () => {
-                    //console.log('connected to target');
+                    //Global.log('connected to target');
                 });
             }
 
             sourceSocket.on('error', (err: any) => {
-                console.error(`TcpProxy client error ${sourcePort}: ${err}`);
+                Global.error(`TcpProxy client error ${sourcePort}: ${err}`);
             })
 
             targetSocket.on('error', (err) => {
-                console.error(`TcpProxy server error ${sourcePort}: ${err}`);
+                Global.error(`TcpProxy server error ${sourcePort}: ${err}`);
             })
 
             // Handle data from source (client)
             sourceSocket.on('data', async (data: Buffer) => {
-                //console.log('request');
+                //Global.log('request');
                 const request = {
                     data,
                     startTime: Date.now(),
@@ -111,7 +111,7 @@ export default class TcpProxy {
 
             // Handle data from target (e.g., database)
             targetSocket.on('data', async (data) => {
-                //console.log('response');
+                //Global.log('response');
                 sourceSocket.write(data);
                 if (requests.length > 0) {
                     const request = requests.pop();
@@ -121,13 +121,13 @@ export default class TcpProxy {
 
             // Handle source socket closed
             sourceSocket.on('close', () => {
-                console.log(`TcpProxy client closed ${sourcePort} source connection`);
+                Global.log(`TcpProxy client closed ${sourcePort} source connection`);
                 targetSocket.end();
             });
 
             // Handle target socket closed
             targetSocket.on('close', () => {
-                console.log(`TcpProxy server ${targetPort} closed target connection`);
+                Global.log(`TcpProxy server ${targetPort} closed target connection`);
                 sourceSocket.end();
             });
 
@@ -179,7 +179,7 @@ export default class TcpProxy {
                     }
 
                     if (requestString.length > 0) {
-                        //console.log('processData', sequenceNumber);
+                        //Global.log('processData', sequenceNumber);
                         const endpoint = '';
 
                         let message = await SocketIoMessage.buildRequest(

--- a/server/src/formatters/SqlFormatter.ts
+++ b/server/src/formatters/SqlFormatter.ts
@@ -2,6 +2,7 @@ import sqlFormatter from 'sql-formatter';
 import { NO_RESPONSE } from '../../../common/Message';
 import HexFormatter from './HexFormatter';
 import SqlCommand from './SqlCommand';
+import Global from '../Global';
 
 export default class SqlFormatter{
 	formattedQuery: any;
@@ -68,7 +69,7 @@ export default class SqlFormatter{
 			// Error?
 			if (fieldCount === 255) {
 				this.errorCode = buf.readUInt16LE(5);
-				console.log('SQL error code:', this.errorCode);
+				Global.log('SQL error code:', this.errorCode);
 				return HexFormatter.format(buf);
 			}
 
@@ -82,7 +83,7 @@ export default class SqlFormatter{
 
 				pktOffset = packet.nextOffset(); // next payload packet
 			}
-			//console.log(colNames);
+			//Global.log(colNames);
 			for(; pktOffset !== null; pktOffset = packet.nextOffset(), ++rowCount) {
 				// Skip EOF markers
 				for(let len = buf.readUInt8(pktOffset + 4);
@@ -105,7 +106,7 @@ export default class SqlFormatter{
 
 						const colName = colNames[i];
 						const fieldValue = isNull ? 'NULL' : buf.toString('utf8', subCvOffset, subCvOffset+len);
-						//console.log(colName, '=', fieldValue);
+						//Global.log(colName, '=', fieldValue);
 
 						formattedResults.push(`  ${colName} = ${fieldValue}`);
 						if(!isNull) subCvOffset += len;
@@ -166,7 +167,7 @@ class MySqlPacket {
 		this.offset = offset;
 		this.packetLength = this.toUInt24(offset);
 		this.packetNumber = this.buf.readUInt8(offset+3);
-		//console.log(`Payload Packet: number=${this.packetNumber} length=${this.packetOffset}`);
+		//Global.log(`Payload Packet: number=${this.packetNumber} length=${this.packetOffset}`);
 
 		return offset;
 	}


### PR DESCRIPTION
1) Retransmit messages that are lost when the socket disconnects unexpectedly.  
2) Disable verbose logging to terminal.
3) Shift frontend message array 1 at a time when limit is exceeded.   Shift by 100 at a time is forcing the socket to unexpectedly disconnect.