### PR TITLE
Do pacing on the socket to the browser

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -43,6 +43,9 @@ for(var i = 2; i < process.argv.length; ++i) {
 			})
 
 			break;
+		case '--debug':
+			Global.debug = true;
+			break;
 		default:
 			usage();
 			console.error('\nInvalid option: '+process.argv[i]);
@@ -56,10 +59,11 @@ if (listen.length === 0) {
 }
 
 function usage() {
-	console.log('\nUsage: npm start [--listen [host:]port] [--listenHttps [host:]port]');
+	console.log('\nUsage: npm start [--listen [host:]port] [--listenHttps [host:]port] [--debug]');
 	console.log('\nOptions:');
 	console.log('\t--listen - listen for incoming http connections.  Default is 8888.');
 	console.log('\t--listenHttps - listen for incoming https connections.');
+	console.log('\t--debug - log verbose debug messages to terminal.');
 	console.log('\nExample: npm start -- --listen 8888 --listenHttps 9999');
 }
 

--- a/client/src/store/MessageQueueStore.ts
+++ b/client/src/store/MessageQueueStore.ts
@@ -53,8 +53,7 @@ export default class MessageQueueStore {
 		return this.stores;
 	}
 
-	@action public insert(socketSeqNum: number, message: Message) {
-		// console.log('insert', socketSeqNum, message.sequenceNumber);
+	@action public insert(message: Message) {
 		if (this.stopped) return;
 		if (!message.proxyConfig?.recording) return;
 

--- a/client/src/store/SocketStore.ts
+++ b/client/src/store/SocketStore.ts
@@ -37,9 +37,11 @@ export default class SocketStore {
 			console.log('socket error', e);
 		});
 
-		this.socket.on('reqResJson', (socketSeqNum: number, message: Message, callback: any) => {
-			messageQueueStore.insert(socketSeqNum, message);
-			callback(`${socketSeqNum} ${message.sequenceNumber} socket.io response`);
+		this.socket.on('reqResJson', (message: Message, callback: any) => {
+			messageQueueStore.insert(message);
+			if (callback) {
+				callback(`${message.sequenceNumber} socket.io callback`);
+			}
 		});
 	}
 

--- a/server/src/Global.ts
+++ b/server/src/Global.ts
@@ -1,20 +1,19 @@
 import ProxyConfigs from './ProxyConfigs';
 
-const DEBUG = false;
-
 export default class Global {
     static proxyConfigs: ProxyConfigs;
     static nextSequenceNumber: number = 0;
+    static debug = false;
 
     static log(...args: any[]) {
-        if (DEBUG) {
-            console.log(args);
+        if (Global.debug) {
+            console.log(args.join(' '));
         }
     }
 
     static error(...args: any[]) {
-        if (DEBUG) {
-            console.error(args);
+        if (Global.debug) {
+            console.error('error: ' + args.join(' '));
         }
     }
 }


### PR DESCRIPTION
The socket used to send captured messages to the browser is getting overrun and disconnects.  This PR adding pacing to prevent the browser side of the socket from being overrun.